### PR TITLE
Fix the typings

### DIFF
--- a/traffic_portal/app/src/common/directives/treeSelect/TreeSelectDirective.d.ts
+++ b/traffic_portal/app/src/common/directives/treeSelect/TreeSelectDirective.d.ts
@@ -17,18 +17,51 @@
  * under the License.
  */
 
-export namespace TreeSelectDirective {
-   export interface TreeData {
-       name: string;
-       id: string;
-       children: TreeData[];
-    }
-   export interface RowData {
-       label: string;
-       value: string;
-       depth: number;
-       collapsed: boolean;
-       hidden: boolean;
-       children: RowData[];
-   }
+export interface TreeData {
+	name: string;
+	id: string;
+	children: TreeData[];
+}
+export interface RowData {
+	label: string;
+	value: string;
+	depth: number;
+	collapsed: boolean;
+	hidden: boolean;
+	children: RowData[];
+}
+
+
+/**
+ * Properties added to an Angular Scope either by directive binding or by being
+ * declared in the `link` function.
+ */
+export interface TreeSelectScopeProperties {
+	/** Returns true if the row data should be displayed after filtering. */
+ 	checkFilters: (row: RowData)=>boolean;
+ 	/** When collapse icon is clicked on row data. */
+	collapse: (row: RowData, evt: Event)=>void;
+	/**
+	 * Gets the FontAwesome icon class based on if the row data has children and
+	 * is collapsed.
+	 */
+	getClass: (row: RowData)=>string;
+	/** Used for form validation, will be assigned to an id attribute. */
+	handle: string;
+ 	initialValue: string;
+	/**
+	 * Used to properly update the parent on value change, useful for
+	 * validation.
+	 */
+	onUpdate: (output: {value: string})=>void;
+	searchText: string;
+	/** Updates the selection when clicking a dropdown option. */
+	select: (row: RowData)=>void;
+	selected: RowData | null;
+	shown: boolean;
+	/** Toggle the dropdown menu. */
+	toggle: ()=>void;
+	treeData: Array<TreeData>;
+	/** Non-recursed ordered list of rows to display (before filtering). */
+	treeRows: Array<RowData>;
 }


### PR DESCRIPTION
A summary of what I did (not everything was necessary):

* Angular properties not imported
* Dynamically adding properties that don't need to be accessed in the template
* Namespace types not imported
* Namespace not necessary
* `scope.selected` set dynamically but value never read
* implicit `any`-typed parameter in click handler
* click handler JSDoc not bound to any visible symbol - removed
* parameter to `collapseRecurse` typed as `boolean | null` instead of optional
* unused parameter to `closeSelect`
* fuzzy match loops over own properties of string primitive (which typescript doesn't like but appears to work fine in reality) switched to collection loop using `of`
* `evt` parameter of `collapse` has implicit `any` type
* incomplete description on `checkFilters`
* simplify `scope.$watch` callback
* changed a bunch of `const funcName = function() {...` to `function funcName() {...` or fat-arrow functions

oh and one last thing you may not have noticed not a big deal but
# TABS > SPACES I CHANGED YOUR FAKE INDENTATION TO REAL INDENTATION
# USA USA USA USA

`scope` used to have an implicit `any`, which is why you could access things willy-nilly. Everything is now strongly typed.

I couldn't get importing the namespace to work, so I quickly gave up. It's already module-scoped anyway; since you have to access it as an import the namespace doesn't do anything but get in the way imo.